### PR TITLE
Update dev environment and complex exercise UI improvements

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,10 +44,6 @@ jobs:
           # Install from fe directory which will handle the workspace
           pnpm install --frozen-lockfile
 
-      - name: Build curriculum package
-        working-directory: curriculum
-        run: pnpm run build
-
       - name: Build application
         working-directory: fe
         run: pnpm run build

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -44,10 +44,6 @@ jobs:
           # Install from fe directory which will handle the workspace
           pnpm install --frozen-lockfile
 
-      - name: Build curriculum package
-        working-directory: curriculum
-        run: pnpm run build
-
       - name: Run TypeScript type check
         working-directory: fe
         run: npx tsc --noEmit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,10 +48,6 @@ jobs:
           # Install from fe directory which will handle the workspace
           pnpm install --frozen-lockfile
 
-      - name: Build curriculum package
-        working-directory: curriculum
-        run: pnpm run build
-
       - name: Run linter
         working-directory: fe
         run: pnpm run lint

--- a/app/dev/complex-exercise/page.tsx
+++ b/app/dev/complex-exercise/page.tsx
@@ -1,5 +1,5 @@
 import ComplexExercise from "@/components/complex-exercise/ComplexExercise";
 
 export default function ComplexExerciseDevPage() {
-  return <ComplexExercise exerciseSlug="basic-movement" />;
+  return <ComplexExercise exerciseSlug="maze-solve-basic" />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -651,3 +651,7 @@ body {
         }
     }
 }
+
+.container-size {
+    container-type: size;
+}

--- a/bin/dev
+++ b/bin/dev
@@ -1,3 +1,16 @@
 #!/usr/bin/env sh
 pnpm install
+
+# Start interpreters watch in background
+(cd ../interpreters && pnpm run dev) &
+INTERPRETERS_PID=$!
+
+# Start curriculum watch in background
+(cd ../curriculum && pnpm run dev) &
+CURRICULUM_PID=$!
+
+# Start Next.js dev server
 pnpm dev
+
+# Kill background processes when this script exits
+trap "kill $INTERPRETERS_PID $CURRICULUM_PID 2>/dev/null" EXIT

--- a/components/complex-exercise/ComplexExercise.tsx
+++ b/components/complex-exercise/ComplexExercise.tsx
@@ -83,7 +83,7 @@ function ComplexExerciseContent({ orchestrator }: { orchestrator: Orchestrator }
               <h2 className="text-lg font-semibold text-gray-700">Code Editor</h2>
             </div>
             <CodeEditor />
-            <div className="border-t border-gray-200 p-4">
+            <div className="border-t border-gray-200 p-4 max-h-[50%] flex flex-col overflow-hidden">
               <TestResultsView />
             </div>
 

--- a/components/complex-exercise/ComplexExercise.tsx
+++ b/components/complex-exercise/ComplexExercise.tsx
@@ -82,9 +82,7 @@ function ComplexExerciseContent({ orchestrator }: { orchestrator: Orchestrator }
             <div className="bg-white border-b border-gray-200 px-4 py-2">
               <h2 className="text-lg font-semibold text-gray-700">Code Editor</h2>
             </div>
-            <div className="flex-1 p-4">
-              <CodeEditor />
-            </div>
+            <CodeEditor />
             <div className="border-t border-gray-200 p-4">
               <TestResultsView />
             </div>

--- a/components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx
+++ b/components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx
@@ -28,6 +28,14 @@ export function InspectedTestResultView() {
     }
 
     viewContainerRef.current.innerHTML = "";
+    result.view.classList.add(
+      "container-size",
+      "aspect-square",
+      "max-h-[100cqh]",
+      "max-w-[100cqw]",
+      "bg-white",
+      "relative"
+    );
     viewContainerRef.current.appendChild(result.view);
     result.view.style.display = "block";
   }, [result]);

--- a/components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx
+++ b/components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx
@@ -54,7 +54,10 @@ export function InspectedTestResultView() {
         result={result}
       />
 
-      <div className={assembleClassNames("spotlight", "flex-grow")} ref={viewContainerRef} id="view-container" />
+      <div
+        className="spotlight flex-grow relative p-2.5 bg-white [container-type:size] min-w-[300px] aspect-square flex-shrink"
+        ref={viewContainerRef}
+      />
     </div>
   );
 }

--- a/components/complex-exercise/ui/test-results-view/TestResultsView.tsx
+++ b/components/complex-exercise/ui/test-results-view/TestResultsView.tsx
@@ -21,12 +21,12 @@ export default function TestResultsView() {
   const allTestsPassed = testSuiteResult.tests.every((test) => test.status === "pass");
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg">
+    <div className="bg-white border border-gray-200 rounded-lg flex flex-col overflow-hidden">
       <div className="border-b border-gray-200 px-4 py-2">
         <h3 className="text-lg font-semibold text-gray-700">Test Results</h3>
       </div>
 
-      <div className="p-4 space-y-4">
+      <div className="p-4 space-y-4 flex flex-col overflow-hidden">
         {/* Main test results */}
         {hasTests && (
           <div>
@@ -48,11 +48,7 @@ export default function TestResultsView() {
         )}
 
         {/* Test result details */}
-        {currentTest && (
-          <div className="border-t border-gray-200 pt-4">
-            <InspectedTestResultView />
-          </div>
-        )}
+        {currentTest && <InspectedTestResultView />}
       </div>
     </div>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: true
   },
-  transpilePackages: ["interpreters"],
+  transpilePackages: ["interpreters", "@jiki/curriculum"],
   allowedDevOrigins: ["localhost", "local.exercism.io"]
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)
+      onchange:
+        specifier: ^7.1.0
+        version: 7.1.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -529,6 +532,14 @@ packages:
   "@bcoe/v8-coverage@0.2.3":
     resolution:
       { integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw== }
+
+  "@blakeembrey/deque@1.0.5":
+    resolution:
+      { integrity: sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg== }
+
+  "@blakeembrey/template@1.2.0":
+    resolution:
+      { integrity: sha512-w/63nURdkRPpg3AXbNr7lPv6HgOuVDyefTumiXsbXxtIwcuk5EXayWR5OpSwDjsQPgaYsfUSedMduaNOjAYY8A== }
 
   "@codemirror/autocomplete@6.18.7":
     resolution:
@@ -2261,6 +2272,10 @@ packages:
       { integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw== }
     engines: { node: ">= 8" }
 
+  arg@4.1.3:
+    resolution:
+      { integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA== }
+
   argparse@1.0.10:
     resolution:
       { integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg== }
@@ -2460,6 +2475,11 @@ packages:
     resolution:
       { integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw== }
 
+  binary-extensions@2.3.0:
+    resolution:
+      { integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw== }
+    engines: { node: ">=8" }
+
   brace-expansion@1.1.12:
     resolution:
       { integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg== }
@@ -2564,6 +2584,11 @@ packages:
     resolution:
       { integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw== }
     engines: { node: ">= 16" }
+
+  chokidar@3.6.0:
+    resolution:
+      { integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw== }
+    engines: { node: ">= 8.10.0" }
 
   chownr@3.0.0:
     resolution:
@@ -3585,6 +3610,11 @@ packages:
       { integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ== }
     engines: { node: ">= 0.4" }
 
+  is-binary-path@2.1.0:
+    resolution:
+      { integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw== }
+    engines: { node: ">=8" }
+
   is-boolean-object@1.2.2:
     resolution:
       { integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A== }
@@ -4467,6 +4497,11 @@ packages:
     resolution:
       { integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w== }
 
+  onchange@7.1.0:
+    resolution:
+      { integrity: sha512-ZJcqsPiWUAUpvmnJri5TPBooqJOPmC0ttN65juhN15Q8xA+Nbg3BaxBHXQ45EistKKlKElb0edmbPWnKSBkvMg== }
+    hasBin: true
+
   onetime@5.1.2:
     resolution:
       { integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg== }
@@ -4756,6 +4791,11 @@ packages:
     resolution:
       { integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg== }
     engines: { node: ">=0.10.0" }
+
+  readdirp@3.6.0:
+    resolution:
+      { integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA== }
+    engines: { node: ">=8.10.0" }
 
   redent@3.0.0:
     resolution:
@@ -5926,6 +5966,10 @@ snapshots:
       "@babel/helper-validator-identifier": 7.27.1
 
   "@bcoe/v8-coverage@0.2.3": {}
+
+  "@blakeembrey/deque@1.0.5": {}
+
+  "@blakeembrey/template@1.2.0": {}
 
   "@codemirror/autocomplete@6.18.7":
     dependencies:
@@ -7329,6 +7373,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  arg@4.1.3: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -7541,6 +7587,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  binary-extensions@2.3.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -7625,6 +7673,18 @@ snapshots:
   char-regex@1.0.2: {}
 
   check-error@2.1.1: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   chownr@3.0.0: {}
 
@@ -8045,7 +8105,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8067,7 +8127,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@2.6.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8611,6 +8671,10 @@ snapshots:
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
 
   is-boolean-object@1.2.2:
     dependencies:
@@ -9580,6 +9644,16 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onchange@7.1.0:
+    dependencies:
+      "@blakeembrey/deque": 1.0.5
+      "@blakeembrey/template": 1.2.0
+      arg: 4.1.3
+      chokidar: 3.6.0
+      cross-spawn: 7.0.6
+      ignore: 5.3.2
+      tree-kill: 1.2.2
+
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -9858,6 +9932,10 @@ snapshots:
       warning: 4.0.3
 
   react@19.1.0: {}
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
 
   redent@3.0.0:
     dependencies:

--- a/tests/mocks/createTestExercise.ts
+++ b/tests/mocks/createTestExercise.ts
@@ -11,10 +11,14 @@ export function createTestExercise(overrides?: Partial<ExerciseDefinition>): Exe
     title: "Test Exercise",
     instructions: "This is a test exercise",
     estimatedMinutes: 5,
+    levelId: "level-1",
     initialCode: "// Test code",
     ExerciseClass: TestExercise,
     tasks,
     scenarios,
+    solutions: {
+      jikiscript: "// Test solution"
+    },
     ...overrides
   };
 }

--- a/tests/mocks/test-exercise/index.ts
+++ b/tests/mocks/test-exercise/index.ts
@@ -7,12 +7,15 @@ export const testExerciseDefinition: ExerciseDefinition = {
   title: "Test Exercise",
   instructions: "This is a test exercise for unit tests",
   estimatedMinutes: 5,
+  levelId: "level-1",
   initialCode: "// Test code",
   ExerciseClass: TestExercise,
   tasks,
   scenarios,
   hints: ["Test hint 1", "Test hint 2"],
-  solution: "move()\nmove()\nmove()\nmove()\nmove()"
+  solutions: {
+    jikiscript: "move()\nmove()\nmove()\nmove()\nmove()"
+  }
 };
 
 export default testExerciseDefinition;


### PR DESCRIPTION
## Summary

- Enhanced `bin/dev` script to watch interpreters and curriculum repos in parallel for improved development workflow
- Updated complex exercise dev page to use `maze-solve-basic` exercise
- Improved test results view with container-based sizing for proper aspect ratio preservation
- Removed redundant padding from code editor container for better layout
- Added `@jiki/curriculum` to transpiled packages in Next.js config
- Added `container-size` CSS utility for container queries
- Fixed test mocks to match updated `ExerciseDefinition` interface

## Test plan

- [x] All tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Verify dev server starts correctly with parallel watchers
- [ ] Verify complex exercise page renders correctly
- [ ] Verify test results view maintains aspect ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)